### PR TITLE
Patch 2 for inheriting object properties when parsing json-bigint

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -88,6 +88,7 @@ var json_parse = function (options) {
     useNativeBigInt: false, // toggles whether to use native BigInt instead of bignumber.js
     protoAction: 'error',
     constructorAction: 'error',
+    objectBaseClass: Object, // using object because we want to inherit proto properties such as hasOwnProperty
   };
 
   // If there are options, then use them to override the default _options
@@ -327,7 +328,7 @@ var json_parse = function (options) {
       // Parse an object value.
 
       var key,
-        object = Object.create(null);
+        object = Object.create(_options.objectBaseClass);
 
       if (ch === '{') {
         next('{');


### PR DESCRIPTION
2nd attempt so that Object properties get inherited when parsing bigint numbers